### PR TITLE
nifi: fix https web properties when nifi is secure

### DIFF
--- a/templates/nifi.properties.j2
+++ b/templates/nifi.properties.j2
@@ -143,9 +143,6 @@ nifi.remote.input.http.transaction.ttl=30 sec
 # web properties #
 nifi.web.war.directory=./lib
 {% if nifi_is_secure -%}
-nifi.web.http.host={{ nifi_input_socket_host }}
-nifi.web.http.port={{ nifi_web_http_port }}
-nifi.web.http.network.interface.default=
 nifi.web.https.host={{ nifi_input_socket_host }}
 nifi.web.https.port={{ nifi_web_https_port }}
 nifi.web.https.network.interface.default=
@@ -153,6 +150,7 @@ nifi.web.proxy.host={{ nifi_web_proxy_host }}
 {% else -%}
 nifi.web.http.host={{ nifi_input_socket_host }}
 nifi.web.http.port={{ nifi_web_http_port }}
+nifi.web.http.network.interface.default=
 nifi.web.https.host=
 nifi.web.https.port=
 nifi.web.https.network.interface.default=


### PR DESCRIPTION
When nifi_is_secure is enable, we only use https ports.
If both is in the configuration (http and https) nifi wont startup.